### PR TITLE
Remove conflicting ToRunning stage

### DIFF
--- a/services/supervisor.go
+++ b/services/supervisor.go
@@ -359,12 +359,17 @@ func (c *Supervisor) superviseAction(analysisResult *RunStatusAnalysisResult) (t
 
 		return analysisResult.ObjectUID, nil
 	case ToRunning:
-		checkpointClone.LifecycleStage = models.LifecycleStageRunning
-		// transition from buffered to running
-		err := c.cqlStore.UpsertCheckpoint(checkpointClone)
-		if err != nil { // coverage-ignore
-			c.logger.V(0).Error(err, "failed to update algorithm submission status", "requestId", analysisResult.RequestId, "algorithm", analysisResult.Algorithm)
-			return analysisResult.ObjectUID, err
+		// only update the checkpoint if the scheduler failed to do so
+		if checkpoint.LifecycleStage != models.LifecycleStageRunning {
+			checkpointClone.LifecycleStage = models.LifecycleStageRunning
+			// transition from buffered to running
+			err := c.cqlStore.UpsertCheckpoint(checkpointClone)
+			if err != nil { // coverage-ignore
+				c.logger.V(0).Error(err, "failed to update algorithm submission status", "requestId", analysisResult.RequestId, "algorithm", analysisResult.Algorithm)
+				return analysisResult.ObjectUID, err
+			}
+
+			return analysisResult.ObjectUID, nil
 		}
 
 		return analysisResult.ObjectUID, nil


### PR DESCRIPTION
`CommitActor` in the scheduler will set the lifecycle stage to RUNNING in most cases. Hence we should not override that and the time. However, of the scheduler fails to do so for any reason, then supervisor should help.